### PR TITLE
Support subscribing to events via EventSource.

### DIFF
--- a/src/services/httpserver.js
+++ b/src/services/httpserver.js
@@ -5,9 +5,33 @@ const body = require('koa-body')
 const cors = require('@koa/cors')
 const route = require('koa-route')
 const static_ = require('koa-static')
+const stream = require('stream')
 
 const minimist = require('minimist')
 const opts = minimist(process.argv.slice(2))
+
+class DBStream extends stream.Readable {
+  constructor (client) {
+    let assertCb = fact => {
+      this.push(`event:assert\ndata:${fact}\n\n`)
+    }
+    let retractCb = fact => {
+      this.push(`event:retract\ndata:${fact}\n\n`)
+    }
+
+    super({
+      destroy: () => {
+        client.off('assert', assertCb)
+        client.off('retract', retractCb)
+      }
+    })
+
+    client.on('assert', assertCb)
+    client.on('retract', retractCb)
+  }
+
+  _read () {}
+}
 
 const log = () => async (context, next) => {
   const requestBody = util.inspect(context.request.body)
@@ -45,6 +69,16 @@ const select = async context => {
 }
 
 const facts = async context => {
+  if (context.accepts('json', 'text/event-stream') == 'text/event-stream') {
+    let stream = new DBStream(context.client)
+    context.req.on('close,finish,error', () => {
+      stream.end()
+    })
+
+    context.type = 'text/event-stream'
+    context.body = stream
+    return
+  }
   const assertions = await context.client.getAllFacts()
   context.body = { assertions }
 }


### PR DESCRIPTION
This now works in any browser:

    let es = new EventSource('/facts');
    es.addEventListener('assert', e => console.log('Asserted:', e.data));
    es.addEventListener('retract', e => console.log('Retracted:', e.data));