### PR TITLE
Switch on support for multipart POSTs

### DIFF
--- a/src/services/httpserver.js
+++ b/src/services/httpserver.js
@@ -85,7 +85,7 @@ const facts = async context => {
 
 const app = new Koa()
 app.use(cors())
-app.use(body())
+app.use(body({ multipart: true }))
 if (opts.verbose) {
   app.use(log())
 }


### PR DESCRIPTION
`parsefacts()` already supports it, it just wasn't enabled at the
`koa-body` level.